### PR TITLE
Load track from url

### DIFF
--- a/apps/content-script/src/app/app.component.spec.ts
+++ b/apps/content-script/src/app/app.component.spec.ts
@@ -1,6 +1,7 @@
 import { MockLoggerModule } from '@plopdown/logger/mock';
 import { MockMessagesModule } from '@plopdown/messages/mock';
 import { MockPlopdownFileModule } from '@plopdown/plopdown-file/mock';
+import { MockWindowRefModule } from '@plopdown/window-ref/mock';
 import { MockVideoAttachmentsComponent } from '@plopdown/plopdown-injector/mock';
 import { MockContentScannerComponent } from './../../mock/content-scanner.component.mock';
 import { TestBed, async } from '@angular/core/testing';
@@ -9,7 +10,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MockLoggerModule, MockMessagesModule, MockPlopdownFileModule],
+      imports: [MockLoggerModule, MockMessagesModule, MockPlopdownFileModule, MockWindowRefModule],
       declarations: [
         AppComponent,
         MockContentScannerComponent,

--- a/apps/content-script/src/app/app.component.spec.ts
+++ b/apps/content-script/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { MockLoggerModule } from '@plopdown/logger/mock';
 import { MockMessagesModule } from '@plopdown/messages/mock';
+import { MockPlopdownFileModule } from '@plopdown/plopdown-file/mock';
 import { MockVideoAttachmentsComponent } from '@plopdown/plopdown-injector/mock';
 import { MockContentScannerComponent } from './../../mock/content-scanner.component.mock';
 import { TestBed, async } from '@angular/core/testing';
@@ -8,7 +9,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MockLoggerModule, MockMessagesModule],
+      imports: [MockLoggerModule, MockMessagesModule, MockPlopdownFileModule],
       declarations: [
         AppComponent,
         MockContentScannerComponent,

--- a/apps/content-script/src/app/app.component.ts
+++ b/apps/content-script/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { SavedVideoRef } from '@plopdown/video-refs';
+import { Track, SavedTrack } from '@plopdown/tracks';
+import { PlopdownFileService, PlopdownFile } from '@plopdown/plopdown-file';
 import { LoggerService } from '@plopdown/logger';
 import {
   ContentScriptPubService,
@@ -10,7 +12,8 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import { map, scan } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { Observable, merge } from 'rxjs';
+import LZString from 'lz-string'
 
 @Component({
   selector: 'plopdown-cs',
@@ -27,10 +30,63 @@ export class AppComponent implements AfterViewInit {
 
   constructor(
     private bgSub: BackgroundSubService,
-    private logger: LoggerService
+    private logger: LoggerService,
+    private fileService: PlopdownFileService,
   ) {
-    this.videoRefs$ = this.bgSub.getVideoRefsFound().pipe(
+
+    const linkVideoRefs = new Observable(subscriber => {
+      if (window.location.hash.startsWith("#plopdown:")) {
+        const linkedVideo = LZString.decompressFromEncodedURIComponent(window.location.hash.split(":")[1]);
+        subscriber.next(linkedVideo);
+      }
+      subscriber.complete();
+    })
+
+    function convertVideoRef(file: PlopdownFile): [SavedVideoRef] {
+      const s: SavedTrack = {
+        _id: "local",
+        _rev: "local",
+        title: file.headers.title,
+        for: file.headers.for,
+        created: file.headers.created,
+        thumbnail: file.headers.thumbnail,
+        authors: file.headers.authors,
+        language: file.headers.language,
+        license: file.headers.license,
+        cues: file.cues,
+      };
+
+      const v: SavedVideoRef = {
+        _id: "local",
+        _rev: "local",
+        xpath: file.headers.xpath,
+        title: file.headers.for,
+        duration: 0,
+        frameOrigin: "",
+        track: s,
+        frameTitle: null,
+        framePath: null,
+        frameSearch: null,
+      }
+      return [v]
+    }
+
+    function importVTT(input: string): PlopdownFile {
+      try {
+        const f: PlopdownFile = fileService.decode(input);
+        return f
+      } catch(e) {
+        console.error(e);
+        throw e;
+      }
+    }
+
+    this.videoRefs$ = merge(linkVideoRefs.pipe(
+      map(importVTT),
+      map(convertVideoRef),
+    ), this.bgSub.getVideoRefsFound().pipe(
       map((res) => res.args[0]),
+    )).pipe(
       scan((refs, videoRefs) => {
         videoRefs.forEach((videoRef) => {
           refs.set(videoRef['_id'], videoRef);

--- a/apps/content-script/src/app/app.component.ts
+++ b/apps/content-script/src/app/app.component.ts
@@ -42,7 +42,7 @@ export class AppComponent implements AfterViewInit {
       return f;
     }
 
-    this.videoRefs$ = merge(window.getPlopdownFromHash().pipe(
+    this.videoRefs$ = merge(window.getHashValueFound().pipe(
       map(importVTT),
       map(this.fileToVideoRef),
     ), this.bgSub.getVideoRefsFound().pipe(

--- a/apps/content-script/src/app/app.module.ts
+++ b/apps/content-script/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { ExtStorageModule } from '@plopdown/ext-storage';
 import { WindowRefModule } from '@plopdown/window-ref';
 import { VideoRefsModule } from '@plopdown/video-refs';
 import { BrowserModule } from '@angular/platform-browser';
+import { PlopdownFileModule } from '@plopdown/plopdown-file';
 import {
   NgModule,
   DoBootstrap,
@@ -27,6 +28,7 @@ import { HttpClientModule } from '@angular/common/http';
 @NgModule({
   declarations: [AppComponent, ContentScannerComponent],
   imports: [
+    PlopdownFileModule,
     BrowserModule,
     ExtStorageModule,
     VideoRefsModule,

--- a/apps/plopdown-ext/src/manifest.json
+++ b/apps/plopdown-ext/src/manifest.json
@@ -5,13 +5,24 @@
   "homepage_url": "https://plopdown.video",
   "description": "Show annotations on top of any html5 web video.",
   "default_locale": "en",
-  "permissions": ["activeTab", "storage", "unlimitedStorage"],
+  "permissions": ["activeTab", "storage", "unlimitedStorage", "<all_urls>"],
   "optional_permissions": ["https://*/*", "http://*/*"],
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": [
+        "content-script/polyfills.js",
+        "content-script/styles.js",
+        "content-script/main.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
   "background": {
     "scripts": [
       "background/runtime.js",

--- a/libs/plopdown-injector/src/lib/video-attachment/video-attachment.component.ts
+++ b/libs/plopdown-injector/src/lib/video-attachment/video-attachment.component.ts
@@ -69,7 +69,7 @@ export class VideoAttachmentComponent implements OnInit, OnDestroy {
   }
 
   private bindAttachment() {
-    if (this.videoElem.duration !== this.duration) {
+    if (this.duration > 0 && this.videoElem.duration !== this.duration) {
       this.logger.error('Duration of video did not match.');
       return;
     }

--- a/libs/window-ref/mock/window-ref.service.mock.ts
+++ b/libs/window-ref/mock/window-ref.service.mock.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
 import { WindowRefService } from '@plopdown/window-ref';
+import { EMPTY } from 'rxjs';
 
 @Injectable()
 export class MockWindowRefService implements Partial<WindowRefService> {
   getDocument = jest.fn();
+  getPlopdownFromHash = jest.fn().mockReturnValue(EMPTY);
 }

--- a/libs/window-ref/mock/window-ref.service.mock.ts
+++ b/libs/window-ref/mock/window-ref.service.mock.ts
@@ -5,5 +5,5 @@ import { EMPTY } from 'rxjs';
 @Injectable()
 export class MockWindowRefService implements Partial<WindowRefService> {
   getDocument = jest.fn();
-  getPlopdownFromHash = jest.fn().mockReturnValue(EMPTY);
+  getHashValueFound = jest.fn().mockReturnValue(EMPTY);
 }

--- a/libs/window-ref/src/lib/window-ref.service.ts
+++ b/libs/window-ref/src/lib/window-ref.service.ts
@@ -1,5 +1,7 @@
 import { WindowRefModule } from './window-ref.module';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import LZString from 'lz-string'
 
 @Injectable({
   providedIn: WindowRefModule,
@@ -19,8 +21,37 @@ export class WindowRefService {
     return this.window.document;
   }
 
+  public getHash() {
+    return this.window.location.hash;
+  }
+
   public getIndexedDB() {
     return this.window.indexedDB;
+  }
+
+  public getPlopdownFromHash(): Observable<string> {
+    const plopdowns = new Observable<string>(subscriber => {
+      this.emitPlopdownFromHash(subscriber);
+      this.window.addEventListener('hashchange', function() {
+        this.emitPlopdownFromHash(subscriber);
+      }.bind(this), false);
+    });
+    return plopdowns;
+  }
+
+  private emitPlopdownFromHash(subscriber) {
+    const plopdown: string = this.parsePlopdownFromHash(this.getHash());
+    if (plopdown !== "") {
+      subscriber.next(plopdown);
+    }
+  }
+
+  private parsePlopdownFromHash(hash: string): string {
+    if (!hash.startsWith("#plopdown:")) {
+      return "";
+    }
+    const linkedVideo: string = LZString.decompressFromEncodedURIComponent(hash.split(":")[1]);
+    return linkedVideo;
   }
 
   public open(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9121,6 +9121,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
+    },
     "@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/jest": "25.1.4",
     "@types/node": "^8.10.60",
+    "@types/lz-string": "^1.3.34",
     "@types/pouchdb": "^6.4.0",
     "@types/sanitize-html": "^1.22.0",
     "@types/uuid": "^7.0.3",


### PR DESCRIPTION
- Changes are made as far forward as possible to make them obvious
- track is lz-string compressed and uri safe base64 encoded
	- url hash is prefixed with `plopdown:`

Possible future simplifications
----
- Drop Saved<Track><VideoRef> in favor of their base implementations
  (Track and VideoRef)
	- the aspects added by the Saved<> interfaces aren't being from
	  this point up.
- URILoaderService or SubService to mimic BackgroundSubService
	- A common interface for Track loading services


#23 